### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,12 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
+          cache: yarn
 
       - name: Install yarn and dependencies
         run: |
@@ -43,11 +44,11 @@ jobs:
           CI: true
 
       - name: Upload Playwright test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 5
+          retention-days: 7
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
Updated GitHub Actions to use newer versions of checkout, setup-node, and upload-artifact actions.